### PR TITLE
Fix bug with two clients.

### DIFF
--- a/src/common/client-app.ts
+++ b/src/common/client-app.ts
@@ -45,11 +45,9 @@ export class App {
 
   applyServerPatch(serverChanges: model.Patch) {
     var current = this.boardVM.toPlain();
-    var myChanges = rfc6902.createPatch(this.shadow, current);
     // I am clonnig patch because the created objects has the same reference
     rfc6902.applyPatch(this.shadow, utils.clone(serverChanges));
     rfc6902.applyPatch(current, serverChanges);
-    rfc6902.applyPatch(current, myChanges);
     this.boardVM.update(current);
     this.shadow = this.boardVM.toPlain();
   }


### PR DESCRIPTION
Fix bug where two clients send at the same time their changes and are applied the last one.
@andresmoschini,
I think that is not necessary that client apply their changes on its own shadow when it´s receiving server changes.
